### PR TITLE
MORPH-11946: Skip bulkSave for deprovisioning servers to avoid row lo…

### DIFF
--- a/src/main/groovy/com/morpheusdata/digitalocean/cloud/sync/VirtualMachineSync.groovy
+++ b/src/main/groovy/com/morpheusdata/digitalocean/cloud/sync/VirtualMachineSync.groovy
@@ -106,7 +106,7 @@ class VirtualMachineSync {
 		for(update in updateList) {
 			ComputeServer currentServer = update.existingItem
 			Map cloudItem = update.masterItem
-			if(currentServer.status != 'provisioning') {
+			if(currentServer.status != 'provisioning' && currentServer.status != 'deprovisioning') {
 				try {
 					def doSave = false
 					def name = cloudItem.name


### PR DESCRIPTION
…ck contention

When a server is being deleted (status='deprovisioning'), internalDeleteServer holds an exclusive row lock for 10-30+ seconds during cascading deletes. If sync runs concurrently, bulkSave attempts to UPDATE the same row and blocks for up to innodb_lock_wait_timeout (50s), causing the cloud to appear stuck in 'syncing' state.

The fix mirrors the existing provisioning guard: skip the update for servers in deprovisioning status since they are about to be deleted anyway. The next sync cycle after the delete completes will properly handle the VM.